### PR TITLE
Updated PHP version

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ export default {
         },
         {
             name: 'PHP',
-            version: '8.0.6',
+            version: '8.0.7',
             config: 'php.ini',
             url: 'https://windows.php.net/downloads/releases/php-{version}-nts-Win32-vs16-x64.zip',
             ignore: ['extras/']


### PR DESCRIPTION
The url with old version (8.0.6) produces an error and PHP couldn't be downloaded. With v8.0.7, it should be ok.